### PR TITLE
Modify grabbing of the vue template

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,9 +132,7 @@ module.exports = function markdownToVueLoader(source, map) {
             component = $$('script').html() || 'export default {};';
             scoped = $style.attr('scoped');
             style = $style.html();
-            $$('template').each((i, element) => {
-              template += $(element).html();
-            });
+            template += $$('template').html();
             break;
           }
 


### PR DESCRIPTION
Adjusting the code so that it only fetches the first template tag as it was previous fetching all and trying to process child template tags that are meant for the inner component slot or general template tags, and don't need to be processing into a component.

Vue Components only have a single root template tag.